### PR TITLE
remove evil minimum/maximum-scale

### DIFF
--- a/chofusai2021/index.html
+++ b/chofusai2021/index.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta name="theme-color" content="#ff0000">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" charset="utf-8">
         <title>工学研究部 - 調布祭特設サイト</title>
         <link href="koken.css" rel="stylesheet">
         <link rel="shortcut icon" href="fig/favicon.ico">


### PR DESCRIPTION
`maximum-scale=1.0, minimum-scale=1.0` is evil because it prevents readers to zoom.

- https://www.w3.org/WAI/standards-guidelines/act/rules/meta-viewport-b4f0c3/
- https://www.w3.org/TR/WCAG22/#resize-text
- https://www.w3.org/WAI/WCAG22/quickref/#resize-text