### PR TITLE
vue-lazyloadの代わりにloading属性を使う

### DIFF
--- a/shinkan2023/index.html
+++ b/shinkan2023/index.html
@@ -258,7 +258,7 @@
                 <div class="card rounded-3 p-2 bg-light">
                   <span class="title">{{ work.title }}</span>
                   <small class="creator">Created by <b>{{ work.creator }}</b></small>
-                  <img class="card-img-top rounded" :src="work.image" :alt="work.title" width="100%">
+                  <img class="card-img-top rounded" :src="work.image" :alt="work.title" loading="lazy">
                   <div class="card-body">
                     <p v-html="work.text" style="padding-left: 0;">
                     </p>
@@ -282,12 +282,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
 <!--Vue.js-->
 <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14"></script>
-<!--Vue lazy-load-->
-<script src="https://unpkg.com/vue-lazyload/vue-lazyload.js"></script>
 <script type="text/javascript">
-    Vue.use(VueLazyload, {
-        preLoad: 1.3,
-    });
     new Vue({
         el: "#app",
         computed: {


### PR DESCRIPTION
Vue Lazyloadを読み込んではいるけど実質使ってない（？）感じだったのでネイティブ仕様の [`loading`](https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-loading) 属性を代わりに使う

ついでに不正な `width` 属性を削除（`width` 属性を指定するときは有効な非負整数でなければならない）

> The attributes, if specified, must have values that are [valid non-negative integers](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-non-negative-integer).

[HTML Standard 4.8.17](https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-width)