### PR TITLE
use swiffy-slider instead of Bootstrap

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -163,20 +163,6 @@ main > h1:first-child {
 	margin-top: 0;
 }
 
-/* .carousel {
-	overflow-x: hidden;
-	scroll-behavior: smooth;
-}
-.carousel-inner {
-	display: flex;
-	margin: 0;
-	overflow-x: auto;
-	scroll-snap-type: x mandatory;
-}
-.carousel img {
-	scroll-snap-align: start;
-} */
-
 .navigation li {
 	margin-bottom: 1em;
 }

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="google-site-verification" content="pI-Qn2xwuSSEHbpOj1SFp0yv3zgW91mymSEFC_IWvdM">
 
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-giJF6kkoqNQ00vy+HMDP7azOuL0xtbfIcaT9wjKHr8RbDVddVHyTfAAsrekwKmP1" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiffy-slider@1.6.0/dist/css/swiffy-slider.min.css" integrity="sha256-bA4I6ewBzTSiwrAJh61J0WZTA5P+yY+Je2qKlNLwDyY=" crossorigin="anonymous">
 <link rel="stylesheet" href="css/main.css">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0">
 
@@ -125,15 +125,11 @@
 	</nav>
 
 	<main>
-		<div class="carousel slide" data-bs-ride="carousel">
-			<div class="carousel-inner">
-				<div class="carousel-item active">
-					<img src="img/toppic1.jpg" class="d-block w-100" alt="" width="770" height="370">
-				</div>
-				<div class="carousel-item">
-					<img src="img/toppic2.jpg" class="d-block w-100" alt="" width="770" height="370">
-				</div>
-			</div>
+		<div class="swiffy-slider slider-nav-autoplay slider-item-ratio" data-slider-nav-autoplay-interval="5000">
+			<figure class="slider-container">
+				<img src="img/toppic1.jpg" alt="" width="770" height="370">
+				<img src="img/toppic2.jpg" alt="" width="770" height="370">
+			</figure>
 		</div>
 		<div class="chofufes-banner">
 			<a href="./shinkan2023/">新入生大歓迎！<br>新歓特設サイトはこちらをクリック!</a>
@@ -166,6 +162,6 @@
 	</main>
 </div>
 <script src="https://platform.twitter.com/widgets.js" async></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-ygbV9kiqUc6oa4msXn9868pTtWMgiQaeYH7/t7LECLbyPA2x65Kgf80OJFdroafW" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/swiffy-slider@1.6.0/dist/js/swiffy-slider.min.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
背景：
カルーセルのためにBootstrapを使用している（ d610cfbb3aaddce1ffacf23373b40c6ca82ae76d より）

問題認識：
Bootstrapの提供する機能はカルーセル以外にほぼ使用されていない。得られる恩恵に対して過大な複雑性を導入していると思う。
index.htmlでしか使用されていないので他のページだとスタイルが微妙に異なる現象が発生している。

提案：
Bootstrapの代わりにカルーセル用ライブラリ[swiffy-slider](https://github.com/dynamicweb/swiffy-slider)を使う。新しめの技術要素（[CSS Scroll Snap Module Level 1](https://www.w3.org/TR/css-scroll-snap-1/)など）で構築されておりシンプル・軽量なことが選定理由。