### PR TITLE
fix YouTube embed overflow

### DIFF
--- a/about.html
+++ b/about.html
@@ -99,12 +99,13 @@
 			<dd>毎週金曜日18:00 </dd>
 		</dl>
 		<iframe
+			class="youtube-embed"
 			width="560"
 			height="315"
 			src="https://www.youtube.com/embed/OgtSbhXeUhg"
 			title="YouTube video player"
 			frameborder="0"
-			allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+			allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
 			allowfullscreen
 		></iframe>
 		<h2>部室の風景</h2>

--- a/css/main.css
+++ b/css/main.css
@@ -251,3 +251,8 @@ main > h1:first-child {
 	background-color: rgba(0, 0, 0, 0.6);
 	color: white;
 }
+.youtube-embed {
+	max-width: 100%;
+	height: auto;
+	aspect-ratio: 16 / 9;
+}


### PR DESCRIPTION
スマートフォンなどの幅が狭いデバイスでYouTubeの埋め込み動画の幅がはみ出すのを修正