### PR TITLE
1カラムレイアウト

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,7 +14,7 @@
 
 <body>
 
-<header class="global-header">
+<header class="container global-header">
 	<a href="./" class="logo">
 		<img src="img/kokenLogo.svg" alt="こうけん" width="815" height="815">
 		<p class="name">
@@ -42,9 +42,6 @@
 			</a>
 		</li>
 	</ul>
-</header>
-
-<div class="container">
 	<nav class="global-nav" aria-label="ナビゲーション">
 		<ul>
 			<li>
@@ -79,7 +76,9 @@
 			</li>
 		</ul>
 	</nav>
+</header>
 
+<div class="container main-container">
 	<main>
 		<h1>工学研究部について</h1>
 		<p>

--- a/css/main.css
+++ b/css/main.css
@@ -61,59 +61,27 @@ img {
 	outline: none;
 }
 
-@media (768px < width) {
-	.container {
-		display: flex;
-		max-width: calc(12rem + 770px);
-		margin: 2rem auto 0;
-		box-sizing: border-box;
-	}
-
-	.global-nav {
-		width: 12rem;
-	}
-
-	.global-nav ul {
-		margin-top: 0;
-	}
-
-	.global-nav a {
-		padding: 0.75rem 1rem;
-	}
-
-	main {
-		box-sizing: border-box;
-		flex: 1;
-		margin-left: 1rem;
-	}
-}
-
-@media (width <= 768px) {
-	.global-nav ul {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-		margin-top: 0;
-	}
-	.global-nav a {
-		padding: 1em;
-	}
-	main {
-		margin-right: 0.5rem;
-		margin-left: 0.5rem;
-	}
+.container {
+	width: 100%;
+	max-width: 1024px;
+	margin-right: auto;
+	margin-left: auto;
+	padding-right: 1rem;
+	padding-left: 1rem;
+	box-sizing: border-box;
 }
 
 .global-header {
 	display: flex;
-	max-width: calc(12rem + 770px);
-	margin-right: auto;
-	margin-left: auto;
-	padding: 1em;
+	flex-wrap: wrap;
+	padding-top: 1em;
 	box-sizing: border-box;
 	justify-content: space-between;
 }
 .global-header .logo {
 	line-height: 1;
+	display: flex;
+	white-space: nowrap;
 }
 .global-header .logo img {
 	width: 48px;
@@ -121,7 +89,6 @@ img {
 	margin-right: 8px;
 }
 .global-header .name {
-	display: inline-block;
 	margin-top: 0;
 	margin-bottom: 0;
 	color: var(--text-color);
@@ -139,30 +106,47 @@ img {
 .global-header-social-links {
 	display: flex;
 	align-items: center;
+	justify-content: center;
 	margin-top: 0;
 	margin-bottom: 0;
 	padding-left: 0;
 	list-style-type: none;
 }
+
 .global-header-social-links a {
 	display: block;
-	padding: 0.25rem;
+	height: 100%;
+	padding-right: 0.25em;
+	padding-left: 0.25em;
 }
 .global-header-social-links img {
-	width: 2rem;
+	width: 2.5rem;
+	height: 2.5rem;
+	vertical-align: middle;
+}
+
+.global-nav {
+	flex-basis: 100%;
+	max-width: 100%;
+	margin-top: 1rem;
 }
 
 .global-nav ul {
+	display: flex;
 	list-style: none;
+	margin-top: 0;
 	margin-bottom: 0;
 	padding: 0;
+	overflow-x: auto;
+	white-space: nowrap;
 	line-height: 1;
 }
 
 .global-nav a {
 	display: block;
+	padding: 0.75rem 1rem 0.75rem;
+	border-radius: 0.5rem;
 	color: var(--text-color);
-	line-height: 1.1;
 	transition: background-color 0.2s ease-out;
 }
 
@@ -176,6 +160,10 @@ img {
 
 .global-nav .en-title {
 	font-size: 11px;
+}
+
+.main-container {
+	margin-top: 1.5rem;
 }
 
 main > h1:first-child {

--- a/docs.html
+++ b/docs.html
@@ -14,7 +14,7 @@
 
 <body>
 
-<header class="global-header">
+<header class="container global-header">
 	<a href="./" class="logo">
 		<img src="img/kokenLogo.svg" alt="こうけん" width="815" height="815">
 		<p class="name">
@@ -42,10 +42,6 @@
 			</a>
 		</li>
 	</ul>
-</header>
-
-
-<div class="container">
 	<nav class="global-nav" aria-label="ナビゲーション">
 		<ul>
 			<li>
@@ -80,7 +76,9 @@
 			</li>
 		</ul>
 	</nav>
+</header>
 
+<div class="container main-container">
 	<main>
 		<h1>過去の部報</h1>
 		<p>閲覧可能なもののみ掲載しています。</p>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
 
 <body>
 
-<header class="global-header">
+<header class="container global-header">
 	<a href="./" class="logo">
 		<img src="img/kokenLogo.svg" alt="こうけん" width="815" height="815">
 		<p class="name">
@@ -89,9 +89,6 @@
 			</a>
 		</li>
 	</ul>
-</header>
-
-<div class="container">
 	<nav class="global-nav" aria-label="ナビゲーション">
 		<ul>
 			<li>
@@ -126,7 +123,9 @@
 			</li>
 		</ul>
 	</nav>
+</header>
 
+<div class="container main-container">
 	<main>
 		<div class="swiffy-slider slider-nav-autoplay slider-item-ratio" data-slider-nav-autoplay-interval="5000">
 			<figure class="slider-container">
@@ -137,7 +136,7 @@
 		<p class="chofufes-banner">
 			<a href="./shinkan2023/">新入生大歓迎！<br>新歓特設サイトはこちらをクリック!</a>
 		</p>
-		<p class="pt-3">
+		<p>
 			工学研究部は電気通信大学の<a href="https://www.uec.ac.jp/campus/extracurricular/club.html">大学公認サークル</a>です。
 		</p>
 		<p>主な活動内容：</p>

--- a/rules.html
+++ b/rules.html
@@ -18,7 +18,7 @@
   </head>
 
   <body>
-    <header class="global-header">
+    <header class="container global-header">
       <a href="./" class="logo">
         <img src="img/kokenLogo.svg" alt="こうけん" width="815" height="815" />
         <p class="name">
@@ -65,9 +65,6 @@
           </a>
         </li>
       </ul>
-    </header>
-
-    <div class="container">
       <nav class="global-nav" aria-label="ナビゲーション">
         <ul>
           <li>
@@ -102,7 +99,9 @@
           </li>
         </ul>
       </nav>
+    </header>
 
+    <div class="container main-container">
       <main>
         <h1>工学研究部の規約・規則について</h1>
         <p>工学研究部の規約・規則を掲載しています。</p>

--- a/works.html
+++ b/works.html
@@ -14,7 +14,7 @@
 
 <body>
 
-<header class="global-header">
+<header class="container global-header">
 	<a href="./" class="logo">
 		<img src="img/kokenLogo.svg" alt="こうけん" width="815" height="815">
 		<p class="name">
@@ -42,9 +42,6 @@
 			</a>
 		</li>
 	</ul>
-</header>
-
-<div class="container">
 	<nav class="global-nav" aria-label="ナビゲーション">
 		<ul>
 			<li>
@@ -79,7 +76,9 @@
 			</li>
 		</ul>
 	</nav>
+</header>
 
+<div class="container main-container">
 	<main>
 		<h1>活動</h1>
 		<h2>近年の活動実績</h2>


### PR DESCRIPTION
左にあったナビゲーションを上部に移設し、メインコンテンツをより大きく見せ、スッキリ感を演出
モバイル表示のナビゲーションをスクロール式にしてメインコンテンツがすぐに目に入るように
めんどくさいメディアクエリを書かなくて良くなったのでCSSが単純化できた

モバイル表示のサンプル：
![127 0 0 1_3000_(Pixel 5) (Phone)](https://user-images.githubusercontent.com/20238714/231768066-7eba28ff-4d60-488b-b9f5-b302bf731f13.png)
