### PR TITLE
ビラのCSSを変更

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -183,9 +183,13 @@ main > h1:first-child {
 	font-size: 3rem;
 }
 
+.shinkan-poster{
+	margin: 1rem 0;
+}
 .shinkan-poster img {
 	/* width: 100%; */
 	border: solid 1px black;
+	max-height: 640px;
 }
 
 .compact-dl dt {


### PR DESCRIPTION
新入生歓迎ビラが横長画面ででかくなるのを直したい＆左揃えにしたい。
縦の長さはてきとうに640pxにしたけど他の単位、値のほうがよかったりしますか？