### PR TITLE
活動実績の更新

### DIFF
--- a/works.html
+++ b/works.html
@@ -59,6 +59,13 @@
 				</dl>
 			</li>
 			<li>
+				技育博
+				<dl class="distribution-list">
+					<dt><a href="https://talent.supporterz.jp/geekhaku/2023/">技育博 2023</a></dt>
+					<dd><a href="https://x.com/ueckoken/status/1656091973835698177">参加告知ツイート</a></dd>
+				</dl>
+			</li>
+			<li>
 				<a href="https://techbookfest.org/organization/5683127032741888">技術書典</a>
 				<dl class="distribution-list">
 					<dt>技術書典18</dt>

--- a/works.html
+++ b/works.html
@@ -45,6 +45,20 @@
 				</dl>
 			</li>
 			<li>
+				<a href="https://tech-circle-expo.connpass.com/">Tech Circle Expo</a>
+				<dl class="distribution-list">
+					<dt><a href="https://tech-circle-expo.connpass.com/event/317970/">Tech Circle Expo #2</a></dt>
+					<dd>「光クロスで10Gの世界へ」</dd>
+				</dl>
+			</li>
+			<li>
+				技書博
+				<dl class="distribution-list">
+					<dt>技書博10</dt>
+					<dd><a href="https://gishohaku.dev/gishohaku10/circles/GYDRuKto0VFrEi4N1nrh">工学研究部 部報 第75号</a></dd>
+				</dl>
+			</li>
+			<li>
 				<a href="https://techbookfest.org/organization/5683127032741888">技術書典</a>
 				<dl class="distribution-list">
 					<dt>技術書典18</dt>

--- a/works.html
+++ b/works.html
@@ -135,16 +135,14 @@
 				<a href="https://ueckoken.livedoor.blog/">ブログ（古）</a>
 			</li>
 		</ul>
-		<h2>主な参加イベント</h2>
+		<h2>主な参加・主催イベント</h2>
 		<dl class="compact-dl">
 			<dt>4月：</dt>
-			<dd>新歓、技術系サークル合同新歓、技術書典</dd>
-			<dt>7月：</dt>
-			<dd>電気通信大学オープンキャンパス</dd>
-			<dt>8月：</dt>
-			<dd>Maker Faire Tokyo</dd>
+			<dd>新歓、技術系サークル合同新歓、技術書典、MakerFaireKyoto、NT函館</dd>
+			<dt>6月：</dt>
+			<dd>NT金沢</dd>
 			<dt>9月：</dt>
-			<dd>合宿、工場見学、技術書典</dd>
+			<dd>合宿、技術書典、NT東京</dd>
 			<dt>11月：</dt>
 			<dd>調布祭（教室展示）</dd>
 			<dt>年1回：</dt>

--- a/works.html
+++ b/works.html
@@ -26,15 +26,33 @@
 		<h2>近年の活動実績</h2>
 		<ul>
 			<li>
+				NT
+				<dl class="distribution-list">
+					<dt>NT金沢 2025</dt>
+					<dd><a href="https://wiki.nicotech.jp/nico_tech/index.php?NT%E9%87%91%E6%B2%A22025">ニコニコ技術部　まとめwiki - NT金沢</a></dd>
+					<dt>NT函館 2024</dt>
+					<dd><a href="https://sites.google.com/view/nt-hakodate/exhibits">出展者一覧ページ</a></dd>
+				</dl>
+			</li>
+			<li>
 				Make
 				<dl class="distribution-list">
+					<dt>Maker Faire Kyoto 2024</dt>
+					<dd><a href="https://makezine.jp/event/makers-mfk2024/m0096/">出展者紹介ページ</a></dd>
 					<dt>Maker Faire Tokyo 2018</dt>
 					<dd><a href="https://twitter.com/ueckoken/status/1025568553708052480">工研部報 59号（電子版）</a></dd>
+					<dd><a href="https://makezine.jp/event/makers2018/m0366/">出展者紹介ページ</a></dd>
 				</dl>
 			</li>
 			<li>
 				<a href="https://techbookfest.org/organization/5683127032741888">技術書典</a>
 				<dl class="distribution-list">
+					<dt>技術書典18</dt>
+					<dd><a href="https://techbookfest.org/product/emsdEZhSAQ6vJPSPABDz2U">工研部報 77号</a></dd>
+					<dt>技術書典17</dt>
+					<dd><a href="https://techbookfest.org/product/aa1BM6PccY1m9higiaFGHd">工研部報 76号</a></dd>
+					<dt>技術書典16</dt>
+					<dd><a href="https://techbookfest.org/product/qSbe1fqbzgcfkTL5BK5YPk">工研部報 75号</a></dd>
 					<dt>技術書典15</dt>
 					<dd><a href="https://techbookfest.org/product/ecidJ6XNxw2fAEkbz3eJ5S">工研部報 74号</a></dd>
 					<dt>技術書典14</dt>
@@ -71,6 +89,7 @@
 			<li>
 				<a href="http://www.chofusai.uec.ac.jp/">調布祭</a>（電通大の学園祭）
 				<dl class="distribution-list">
+					<dt><a href="./event/chofusai/2024/">第74回調布祭</a></dt>
 					<dt><a href="./event/chofusai/2023/">第73回調布祭</a></dt>
 					<dd>工研部報 73,74号</dd>
 					<dd>工研プラレール展示</dd>


### PR DESCRIPTION
2023年頃？から活動実績が更新されていなかったので、更新しました。

追加したもの
- NT金沢2025
- NT函館2024
- MakerFaireKyoto2024
- 技術書典16~18
- 第74回調布祭


また、「主な参加イベント」が実態にそぐわなかったので「参加・主催イベント」とし、最新の情報に更新しました。